### PR TITLE
fix: correct the type of `include` and `exclude` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,34 @@ Compared to the previous approach, this method decouples the React Fast Refresh 
 - For usage with `builtin:swc-loader`, you can refer to the example at [examples/react-refresh](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-refresh/rspack.config.js), When using with `swc-loader`, simply replace `builtin:swc-loader` with `swc-loader`.
 - For usage with `babel-loader`, you can refer to the example at [examples/react-refresh-babel-loader](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-refresh-babel-loader/rspack.config.js)
 
+## Options
+
+### include
+
+- Type: [Rspack.RuleSetCondition](https://rspack.dev/config/module#condition)
+- Default: `/\.([cm]js|[jt]sx?|flow)$/i`
+
+Include files to be processed by the plugin. The value is the same as the `rule.test` option in Rspack.
+
+```js
+new ReactRefreshPlugin({
+  include: [/\.jsx$/, /\.tsx$/],
+});
+```
+
+### exclude
+
+- Type: [Rspack.RuleSetCondition](https://rspack.dev/config/module#condition)
+- Default: `/node_modules/`
+
+Exclude files from being processed by the plugin. The value is the same as the `rule.exclude` option in Rspack.
+
+```js
+new ReactRefreshPlugin({
+  exclude: [/node_modules/, /some-other-module/],
+});
+```
+
 ## Credits
 
 Thanks to the [react-refresh-webpack-plugin](https://github.com/pmmmwh/react-refresh-webpack-plugin) created by [@pmmmwh](https://github.com/pmmmwh), which inspires implement this plugin.

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,3 +1,4 @@
+import type { RuleSetCondition } from '@rspack/core';
 import type { IntegrationType } from './utils/getSocketIntegration';
 
 interface OverlayOptions {
@@ -11,8 +12,18 @@ interface OverlayOptions {
 }
 
 export type PluginOptions = {
-  include?: string | RegExp | (string | RegExp)[] | null;
-  exclude?: string | RegExp | (string | RegExp)[] | null;
+  /**
+   * Include files to be processed by the plugin.
+   * The value is the same as the `rule.test` option in Rspack.
+   * @default /\.([cm]js|[jt]sx?|flow)$/i
+   */
+  include?: RuleSetCondition | null;
+  /**
+   * Exclude files from being processed by the plugin.
+   * The value is the same as the `rule.exclude` option in Rspack.
+   * @default /node_modules/
+   */
+  exclude?: RuleSetCondition | null;
   library?: string;
   forceEnable?: boolean;
   overlay?: boolean | OverlayOptions;


### PR DESCRIPTION
The same as https://github.com/rspack-contrib/rspack-plugin-preact-refresh/pull/8