### PR TITLE
fix: make all overlay options optional

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -42,7 +42,7 @@ export type PluginOptions = {
    * Modify the behavior of the error overlay.
    * @default false
    */
-  overlay?: boolean | OverlayOptions;
+  overlay?: boolean | Partial<OverlayOptions>;
 };
 
 export interface NormalizedPluginOptions extends Required<PluginOptions> {


### PR DESCRIPTION
This PR makes all the options on `PluginOptions['overlay']` optional.

Currently, the following code throws a TypeScript error:

```ts
new ReactRefreshPlugin({ overlay: { sockHost: '...' } })
```

This is because the `OverlayOptions` type requires `entry`, `module`, and `sockIntegration`, despite the fact they have defaults.