### PR TITLE
Export overlay module in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     },
     "./react-refresh": "./client/reactRefresh.js",
     "./react-refresh-entry": "./client/reactRefreshEntry.js",
+    "./overlay": "./client/overlay/index.js",
     "./package.json": "./package.json"
   },
   "scripts": {


### PR DESCRIPTION
## What
Added the overlay module to the package.json exports to make it accessible for external consumption.

## Why
The `ReactRefreshRspackPlugin` accepts a `module` option which should be able to use the default overlay implementation. Currently, without exposing the overlay module, it's not possible to extend or wrap the original overlay functionality.

## How
Added the overlay module to the package exports in package.json.

## Testing
- Verified the overlay module can be imported from the package
- Confirmed the original overlay functionality works when imported externally
