### PR TITLE
feat: support manually inject loader

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import type { NormalizedPluginOptions, PluginOptions } from './options';
 import { getIntegrationEntry } from './utils/getIntegrationEntry';
 
 export type { PluginOptions };
+export const loader = 'builtin:react-refresh-loader';
 
 function addEntry(entry: string, compiler: Compiler) {
   new compiler.webpack.EntryPlugin(compiler.context, entry, {
@@ -72,15 +73,17 @@ class ReactRefreshRspackPlugin {
       $ReactRefreshRuntime$: reactRefreshPath,
     }).apply(compiler);
 
-    compiler.options.module.rules.unshift({
-      // biome-ignore lint: exists
-      include: this.options.include!,
-      exclude: {
+    if (this.options.injectLoader) {
+      compiler.options.module.rules.unshift({
         // biome-ignore lint: exists
-        or: [this.options.exclude!, [...runtimePaths]].filter(Boolean),
-      },
-      use: 'builtin:react-refresh-loader',
-    });
+        include: this.options.include!,
+        exclude: {
+          // biome-ignore lint: exists
+          or: [this.options.exclude!, [...runtimePaths]].filter(Boolean),
+        },
+        use: loader,
+      });
+    }
 
     const definedModules: Record<string, string | boolean> = {
       // For Multiple Instance Mode

--- a/src/options.ts
+++ b/src/options.ts
@@ -43,6 +43,12 @@ export type PluginOptions = {
    * @default false
    */
   overlay?: boolean | Partial<OverlayOptions>;
+
+  /**
+   * Whether to inject the builtin:react-refresh-loader
+   * @default true
+   */
+  injectLoader?: boolean;
 };
 
 export interface NormalizedPluginOptions extends Required<PluginOptions> {
@@ -90,6 +96,7 @@ export function normalizeOptions(
   d(options, 'include', /\.([cm]js|[jt]sx?|flow)$/i);
   d(options, 'library');
   d(options, 'forceEnable', false);
+  d(options, 'injectLoader', true);
   options.overlay = normalizeOverlay(options.overlay);
   return options as NormalizedPluginOptions;
 }


### PR DESCRIPTION
Currently this is basically inject react refresh loader for every module, it works for normal cases, but for some complex cases, they need more precise control over how to inject the loader.