### PR TITLE
feat: support custom inject entry runtime

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,8 +54,10 @@ class ReactRefreshRspackPlugin {
       options: this.options,
     });
 
-    for (const entry of addEntries.prependEntries) {
-      addEntry(entry, compiler);
+    if (this.options.injectEntry) {
+      for (const entry of addEntries.prependEntries) {
+        addEntry(entry, compiler);
+      }
     }
 
     if (

--- a/src/options.ts
+++ b/src/options.ts
@@ -49,6 +49,12 @@ export type PluginOptions = {
    * @default true
    */
   injectLoader?: boolean;
+
+  /**
+   * Whether to inject the client/reactRefreshEntry.js
+   * @default true
+   */
+  injectEntry?: boolean;
 };
 
 export interface NormalizedPluginOptions extends Required<PluginOptions> {
@@ -97,6 +103,7 @@ export function normalizeOptions(
   d(options, 'library');
   d(options, 'forceEnable', false);
   d(options, 'injectLoader', true);
+  d(options, 'injectEntry', true);
   options.overlay = normalizeOverlay(options.overlay);
   return options as NormalizedPluginOptions;
 }

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -15,7 +15,7 @@ type CompilationCallback = (error: Error | null, stats: Stats | undefined, outpu
 
 const uniqueName = "ReactRefreshLibrary";
 
-const compileWithReactRefresh = (fixturePath: string, refreshOptions: PluginOptions, callback:CompilationCallback) => {
+const compileWithReactRefresh = (fixturePath: string, refreshOptions: PluginOptions, callback: CompilationCallback) => {
 	let dist = path.join(fixturePath, "dist");
 	rspack(
 		{
@@ -150,6 +150,19 @@ describe("react-refresh-rspack-plugin", () => {
 			},
 			(_, __, { reactRefresh, fixture, runtime, vendor }) => {
 				expect(fixture).not.toContain("function $RefreshReg$");
+				done();
+			}
+		);
+	});
+
+	it("should allow custom inject entry when compiling", done => {
+		compileWithReactRefresh(
+			path.join(__dirname, "fixtures/custom"),
+			{
+				injectEntry: false,
+			},
+			(_, __, { reactRefresh, fixture, runtime, vendor }) => {
+				expect(reactRefresh).not.toContain("RefreshRuntime.injectIntoGlobalHook(safeThis)");
 				done();
 			}
 		);


### PR DESCRIPTION
Currently this is basically inject react refresh entry for every entry points, it works for normal cases, but for some complex cases, they need more precise control over how to inject the entry for specific entry point.