### PR TITLE
fix: failed to resolve phantom dependency

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import {
   getSocketIntegration,
 } from './utils/getSocketIntegration';
 
-import { type Compiler, RuntimeGlobals } from '@rspack/core';
+import type { Compiler } from '@rspack/core';
 import type { NormalizedPluginOptions, PluginOptions } from './options';
 import { getIntegrationEntry } from './utils/getIntegrationEntry';
 
@@ -133,7 +133,7 @@ class ReactRefreshRspackPlugin {
       compilation.hooks.additionalTreeRuntimeRequirements.tap(
         PLUGIN_NAME,
         (_, runtimeRequirements) => {
-          runtimeRequirements.add(RuntimeGlobals.moduleCache);
+          runtimeRequirements.add(compiler.rspack.RuntimeGlobals.moduleCache);
         },
       );
     });


### PR DESCRIPTION
Fix failed to resolve phantom dependency `@rspack/core`, it is a dev dependency of this plugin.

<img width="1136" alt="Screenshot 2025-04-21 at 10 30 01" src="https://github.com/user-attachments/assets/0b7f9cc6-1a71-4c8b-91f7-4f9d3fca08d6" />
