### PR TITLE
fix: TS error when skipLibCheck is false

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -140,5 +140,5 @@ class ReactRefreshRspackPlugin {
   }
 }
 
-// @ts-expect-error output module.exports
-export = ReactRefreshRspackPlugin;
+export default ReactRefreshRspackPlugin;
+export { ReactRefreshRspackPlugin };


### PR DESCRIPTION
Fix TS error when the `skipLibCheck` option of tsconfig.json is set to `false`:

<img width="1124" alt="Screenshot 2025-04-22 at 15 55 01" src="https://github.com/user-attachments/assets/9069c21d-4f29-4c06-91ec-603a12e4b202" />

Using a combination of default export and named export should maintain compatibility with CJS require.