### PR TITLE
fix: incorrect type when required

### DIFF
--- a/exports/index.d.cts
+++ b/exports/index.d.cts
@@ -1,4 +1,3 @@
-import { ReactRefreshRspackPlugin, type PluginOptions } from '../dist/index.js';
+import { ReactRefreshRspackPlugin } from '../dist/index.js';
 
-export type { PluginOptions };
-export default ReactRefreshRspackPlugin;
+export = ReactRefreshRspackPlugin;


### PR DESCRIPTION
Fix incorrect type when required, see: https://github.com/rspack-contrib/rspack-plugin-react-refresh/issues/30

![image](https://github.com/user-attachments/assets/fa4dee32-5c85-44ae-b469-8d34b10b5755)

Note that `export =` can not be used with `export type { PluginOptions }`. Considering that type cannot be required, removing `export type { PluginOptions }` should be feasible.

<img width="1006" alt="Screenshot 2025-04-23 at 21 00 49" src="https://github.com/user-attachments/assets/36908251-b259-4ec8-8c6b-7cbd0c6149de" />



