### PR TITLE
fix: support named export for cjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ Import the plugin in your code:
 // Named import (recommended)
 import { ReactRefreshRspackPlugin } from "@rspack/plugin-react-refresh";
 
-// Default import
-import ReactRefreshRspackPlugin from "@rspack/plugin-react-refresh";
 ```
 
 - CommonJS:

--- a/exports/index.cjs
+++ b/exports/index.cjs
@@ -1,4 +1,7 @@
 // CommonJS wrapper
 const { ReactRefreshRspackPlugin } = require('../dist/index.js');
 
+// default export will be deprecated in next major version
 module.exports = ReactRefreshRspackPlugin;
+
+module.exports.ReactRefreshRspackPlugin = ReactRefreshRspackPlugin;

--- a/exports/index.mjs
+++ b/exports/index.mjs
@@ -1,5 +1,5 @@
 // ES modules wrapper
 import { ReactRefreshRspackPlugin } from '../dist/index.js';
-
+// default export will be deprecated in next major version
 export default ReactRefreshRspackPlugin;
 export { ReactRefreshRspackPlugin };


### PR DESCRIPTION
default export is very fragile in esm-cjs interop, so will be deprecated in future version and only support the following exports in future which can be used in following case
* native esm import: it will just use the index.mjs's `export { ReactRefreshRspackPlugin}`
* esm transpiled to cjs: will use `module.exports.ReactRefreshRspackPlugin = ReactRefreshRspackPlugin`
* native cjs: have to write `const ReactRefreshRspackPlugin = require('ReactRefreshRspackPlugin')`;
```js
import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
```