### PR TITLE
feat: add `test` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Import the plugin in your code:
 ```js
 // Named import (recommended)
 import { ReactRefreshRspackPlugin } from "@rspack/plugin-react-refresh";
-
 ```
 
 - CommonJS:
@@ -101,12 +100,31 @@ Compared to the previous approach, this method decouples the React Fast Refresh 
 
 ## Options
 
+### test
+
+- Type: [Rspack.RuleSetCondition](https://rspack.dev/config/module#condition)
+- Default: `undefined`
+
+Specifies which files should be processed by the React Refresh loader. This option is passed to the `builtin:react-refresh-loader` as the `rule.test` condition.
+
+Works identically to Rspack's [rule.test](https://rspack.dev/config/module#ruletest) option.
+
+```js
+new ReactRefreshPlugin({
+  test: [/\.jsx$/, /\.tsx$/],
+});
+```
+
 ### include
 
 - Type: [Rspack.RuleSetCondition](https://rspack.dev/config/module#condition)
 - Default: `/\.([cm]js|[jt]sx?|flow)$/i`
 
-Include files to be processed by the plugin. The value is the same as the [rule.test](https://rspack.dev/config/module#ruletest) option in Rspack.
+Explicitly includes files to be processed by the React Refresh loader. This option is passed to the `builtin:react-refresh-loader` as the `rule.include` condition.
+
+Use this to limit processing to specific directories or file patterns.
+
+Works identically to Rspack's [rule.include](https://rspack.dev/config/module#ruleinclude) option.
 
 ```js
 new ReactRefreshPlugin({

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,7 @@ class ReactRefreshRspackPlugin {
 
     if (this.options.injectLoader) {
       compiler.options.module.rules.unshift({
+        test: this.options.test,
         // biome-ignore lint: exists
         include: this.options.include!,
         exclude: {

--- a/src/options.ts
+++ b/src/options.ts
@@ -13,10 +13,19 @@ interface OverlayOptions {
 
 export type PluginOptions = {
   /**
-   * Include files to be processed by the plugin.
-   * The value is the same as the `rule.test` option in Rspack.
-   * @default /\.([cm]js|[jt]sx?|flow)$/i
+   * Specifies which files should be processed by the React Refresh loader.
+   * This option is passed to the `builtin:react-refresh-loader` as the `rule.test` condition.
+   * Works identically to Rspack's `rule.test` option.
    * @see https://rspack.dev/config/module#ruletest
+   */
+  test?: RuleSetCondition;
+  /**
+   * Explicitly includes files to be processed by the React Refresh loader.
+   * This option is passed to the `builtin:react-refresh-loader` as the `rule.include` condition.
+   * Use this to limit processing to specific directories or file patterns.
+   * Works identically to Rspack's `rule.include` option.
+   * @default /\.([cm]js|[jt]sx?|flow)$/i
+   * @see https://rspack.dev/config/module#ruleinclude
    */
   include?: RuleSetCondition | null;
   /**

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -128,6 +128,21 @@ describe('react-refresh-rspack-plugin', () => {
     );
   });
 
+  it('should test selected file when compiling', (done) => {
+    compileWithReactRefresh(
+      path.join(__dirname, 'fixtures/custom'),
+      {
+        exclude: null,
+        test: path.join(__dirname, 'fixtures/node_modules/foo'),
+        include: null,
+      },
+      (_, __, { vendor }) => {
+        expect(vendor).toContain('function $RefreshReg$');
+        done();
+      },
+    );
+  });
+
   it('should include selected file when compiling', (done) => {
     compileWithReactRefresh(
       path.join(__dirname, 'fixtures/custom'),


### PR DESCRIPTION
## Summary

This PR adds a new ` test` option. This option is passed to the `builtin:react-refresh-loader` as the `rule.test` condition.

## Motivation

When using this plugin in Rsbuild, I found that the best practice is to keep the plugin's module matching scope consistent with `builtin:swc-loader`, because `builtin:swc-loader` injects `$RefreshReg$` related code into modules, which then needs to be further processed by this plugin.

Therefore, I added a `test` property to this plugin, making it easier for users to set the same `test`, `include`, and `exclude` option values for both `builtin:swc-loader` and `builtin:react-refresh-loader`.
