### PR TITLE
feat: always log error during HMR applying status

### DIFF
--- a/client/refreshUtils.js
+++ b/client/refreshUtils.js
@@ -245,6 +245,8 @@ function executeRuntime(
          * @returns {void}
          */
         function hotErrorHandler(error) {
+          console.error(error);
+
           if (typeof refreshOverlay !== 'undefined' && refreshOverlay) {
             refreshOverlay.handleRuntimeError(error);
           }


### PR DESCRIPTION
While `overlay` is disabled, error happens during applying hot-updates will be suppressed.
So adding this logging, to make this kind of errors always visible to developers.
 