### PR TITLE
feat: add reloadOnRuntimeErrors  config 

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,21 @@ new ReactRefreshPlugin({
 });
 ```
 
+### reloadOnRuntimeErrors
+
+- Type: `boolean`
+- Default: `false`
+
+Config the plugin whether trigger a full page reload when an unrecoverable runtime error is encountered.
+
+Currently, only module factory undefined error is considered as unrecoverable runtime error.
+
+```js
+new ReactRefreshPlugin({
+  reloadOnRuntimeErrors: true,
+});
+```
+
 ## Credits
 
 Thanks to the [react-refresh-webpack-plugin](https://github.com/pmmmwh/react-refresh-webpack-plugin) created by [@pmmmwh](https://github.com/pmmmwh), which inspires implement this plugin.

--- a/client/refreshUtils.js
+++ b/client/refreshUtils.js
@@ -255,9 +255,6 @@ function executeRuntime(
 
           if (typeof refreshOverlay !== 'undefined' && refreshOverlay) {
             refreshOverlay.handleRuntimeError(error);
-          } else {
-            console.log('can afford it keep throw up');
-            // throw error;
           }
 
           if (typeof isTest !== 'undefined' && isTest) {

--- a/client/refreshUtils.js
+++ b/client/refreshUtils.js
@@ -209,6 +209,7 @@ function shouldInvalidateReactRefreshBoundary(prevExports, nextExports) {
 }
 
 var enqueueUpdate = createDebounceUpdate();
+
 function executeRuntime(
   moduleExports,
   moduleId,
@@ -245,8 +246,18 @@ function executeRuntime(
          * @returns {void}
          */
         function hotErrorHandler(error) {
+          if (
+            __reload_on_runtime_errors__ &&
+            isUnrecoverableRuntimeError(error)
+          ) {
+            location.reload();
+          }
+
           if (typeof refreshOverlay !== 'undefined' && refreshOverlay) {
             refreshOverlay.handleRuntimeError(error);
+          } else {
+            console.log('can afford it keep throw up');
+            // throw error;
           }
 
           if (typeof isTest !== 'undefined' && isTest) {
@@ -285,6 +296,10 @@ function executeRuntime(
       }
     }
   }
+}
+
+function isUnrecoverableRuntimeError(error) {
+  return error.message.startsWith('RuntimeError: factory is undefined');
 }
 
 module.exports = Object.freeze({

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,7 @@ class ReactRefreshRspackPlugin {
             compiler.options.output.library,
         ),
       ),
+      __reload_on_runtime_errors__: this.options.reloadOnRuntimeErrors,
     };
     const providedModules: Record<string, string> = {
       __react_refresh_utils__: refreshUtilsPath,

--- a/src/options.ts
+++ b/src/options.ts
@@ -79,6 +79,11 @@ export type PluginOptions = {
    * @default true
    */
   injectEntry?: boolean;
+  /**
+   * Whether to reload the page on runtime errors. E.g: undefined module factory
+   * @default false
+   */
+  reloadOnRuntimeErrors?: boolean;
 };
 
 export interface NormalizedPluginOptions extends Required<PluginOptions> {
@@ -128,6 +133,7 @@ export function normalizeOptions(
   d(options, 'forceEnable', false);
   d(options, 'injectLoader', true);
   d(options, 'injectEntry', true);
+  d(options, 'reloadOnRuntimeErrors', false);
   options.overlay = normalizeOverlay(options.overlay);
   return options as NormalizedPluginOptions;
 }


### PR DESCRIPTION
add a new config `reloadOnRuntimeErrors`
- `reloadOnRuntimeErrors` is disabled by default; while disable, it works the same as before.
- `reloadOnRuntimeErrors` is enabled,  when there an unrecoverable runtime errors happen, the plugin will try to recover by doing a reload.

Currently, we treat **factory undefined** as an unrecoverable runtime error only.
