### PR TITLE
refactor:  early return to void overlay flashing

### DIFF
--- a/client/refreshUtils.js
+++ b/client/refreshUtils.js
@@ -252,6 +252,7 @@ function executeRuntime(
             isUnrecoverableRuntimeError(error)
           ) {
             location.reload();
+            return;
           }
 
           if (typeof refreshOverlay !== 'undefined' && refreshOverlay) {


### PR DESCRIPTION
No need to show error when plugin decide to reload the page.