### PR TITLE
fix: removeChild may throw when render to  `document.body`

### DIFF
--- a/client/overlay/index.js
+++ b/client/overlay/index.js
@@ -240,7 +240,12 @@ function render() {
  */
 function cleanup() {
   // Clean up and reset all internal state.
-  document.body.removeChild(iframeRoot);
+  try {
+    document.body.removeChild(iframeRoot);
+  } catch (e) {
+    // In case user render react app directly to body， will trigger `NotFoundError` when recovery from an Error
+    // https://developer.mozilla.org/en-US/docs/Web/API/Node/removeChild#exceptions
+  }
   scheduledRenderFn = null;
   root = null;
   iframeRoot = null;


### PR DESCRIPTION
## Problem

```js
// app.jsx
function Component() {
  // throw Error("toggle the error");
  return (
    <div>
      <div>Hello</div>
    </div>
  );
}  

// index.jsx
// render to body's directly
const root = ReactDOM.createRoot(document.getElementsByTagName("body")[0]);
```
Make the `Component` throw the error, then comment the `throw` again. 
Overlay will appears as below.
![11caa6cdbafbcc1407d7e5d731eda6f3_MD5](https://github.com/user-attachments/assets/139c54e6-48d9-4218-88d0-5fdac0c1ffe2)

- When user renders app to `document.body` and plugin shows some error
- User correct the error, then React re-renders `document.body`, removes the iframe which the plugin created and appened before; the plugin tries to remove it again. The error happens, and the overlay show a `removeChild` error.


