### PR TITLE
docs: add automatic runtime to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ export default {
             jsc: {
               transform: {
                 react: {
+                  runtime: 'automatic',
                   development: isDev,
                   refresh: isDev,
                 },


### PR DESCRIPTION
## Summary
This PR updates the README SWC React transform example to include `runtime: 'automatic'`, so the documented configuration matches the automatic JSX runtime setup used by current React projects.

## Related Links
None

## Validation
Docs-only change; no runtime checks were run.