### PR TITLE
fix: narrow default node_modules exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,13 @@ new ReactRefreshPlugin({
 ### exclude
 
 - Type: [Rspack.RuleSetCondition](https://rspack.rs/config/module-rules#condition)
-- Default: `/node_modules/`
+- Default: `/[\\/]node_modules[\\/]/`
 
 Exclude files from being processed by the plugin. The value is the same as the [rule.exclude](https://rspack.rs/config/module-rules#rulesexclude) option in Rspack.
 
 ```js
 new ReactRefreshPlugin({
-  exclude: [/node_modules/, /some-other-module/],
+  exclude: [/[\\/]node_modules[\\/]/, /some-other-module/],
 });
 ```
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -21,7 +21,7 @@ export type PluginOptions = {
   /**
    * Exclude files from being processed by the plugin.
    * The value is the same as the `rule.exclude` option in Rspack.
-   * @default /node_modules/
+   * @default /[\\/]node_modules[\\/]/
    * @see https://rspack.rs/config/module-rules#rulesexclude
    */
   exclude?: RuleSetCondition | null;
@@ -95,7 +95,7 @@ export function normalizeOptions(
   options: PluginOptions,
 ): NormalizedPluginOptions {
   d(options, 'test', /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/);
-  d(options, 'exclude', /node_modules/i);
+  d(options, 'exclude', /[\\/]node_modules[\\/]/);
   d(options, 'library');
   d(options, 'forceEnable', false);
   d(options, 'injectLoader', true);

--- a/test/fixtures/contains-node_modules-name/index.js
+++ b/test/fixtures/contains-node_modules-name/index.js
@@ -1,0 +1,3 @@
+import 'foo';
+
+export default 'contains-node_modules-name';

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -160,6 +160,16 @@ describe('react-refresh-rspack-plugin', () => {
     expect(fixture).toContain('function $RefreshReg$');
   });
 
+  it('should include paths that only contain node_modules in the name', async () => {
+    const {
+      outputs: { fixture },
+    } = await compileWithReactRefresh(
+      path.join(import.meta.dirname, 'fixtures/contains-node_modules-name'),
+      {},
+    );
+    expect(fixture).toContain('function $RefreshReg$');
+  });
+
   it('should add library to make sure work in Micro-Frontend', async () => {
     const {
       outputs: { reactRefresh },


### PR DESCRIPTION
## Summary

This PR narrows the default `exclude` option so React Refresh skips only real `node_modules` path segments instead of any path containing the `node_modules` substring. It also updates the README default and adds coverage for paths whose names merely contain `node_modules`.