### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@rspack/plugin-react-refresh",
   "version": "2.0.2",
   "repository": "https://github.com/rstackjs/rspack-plugin-react-refresh",
+  "homepage": "https://github.com/rstackjs/rspack-plugin-react-refresh#readme",
+  "bugs": {
+    "url": "https://github.com/rstackjs/rspack-plugin-react-refresh/issues"
+  },
   "license": "MIT",
   "description": "React refresh plugin for Rspack",
   "type": "module",


### PR DESCRIPTION
## Summary
- add npm `homepage` metadata pointing to the README
- add npm `bugs.url` metadata pointing to the GitHub issue tracker

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json OK')"`
- `git diff --check`
